### PR TITLE
fix: align buttons inline with icon for tighter card layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -46,6 +46,9 @@ h1 {
   padding: 1.25rem;
   margin-bottom: 1rem;
   transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .card:hover {
@@ -125,7 +128,7 @@ h1 {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  margin-bottom: 0.75rem;
+  flex-shrink: 0;
 }
 
 /* Icon circles */
@@ -165,6 +168,7 @@ h1 {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
+  margin-left: auto;
 }
 
 .btn {
@@ -212,7 +216,7 @@ h1 {
 
 /* All-done card */
 #all-done {
-  text-align: center;
+  justify-content: center;
   padding: 3rem 1.25rem;
 }
 


### PR DESCRIPTION
Make card layout a single-row flex container so buttons sit at the same
level as the icon instead of below the title. Closes #8.

https://claude.ai/code/session_01SBPgieVKQYJgzuZhfYm5GX