### PR TITLE
fix: use client local date instead of server UTC for day boundaries

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,15 @@ const TRACK_URL = "https://vrskp6njjbbhbxoyo2j7ipjbay0wnkqb.lambda-url.us-east-1
 // ---- State ----
 let state = null;
 
+// ---- Date helper ----
+function localTodayISO() {
+  const d = new Date();
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
 // ---- DOM helpers ----
 const $ = (sel) => document.querySelector(sel);
 const show = (el) => el.classList.remove("hidden");
@@ -73,7 +82,8 @@ function applyOptimistic(field, value) {
 // ---- API calls ----
 
 async function fetchToday() {
-  const res = await fetch(GET_TODAY_URL);
+  const date = localTodayISO();
+  const res = await fetch(`${GET_TODAY_URL}?date=${date}`);
   if (!res.ok) throw new Error("Failed to load today's data");
   state = await res.json();
   render();
@@ -83,7 +93,7 @@ function track(field, value) {
   fetch(TRACK_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ field, value }),
+    body: JSON.stringify({ field, value, date: localTodayISO() }),
   })
     .then((res) => {
       if (!res.ok) throw new Error("Failed to save");

--- a/lambda/getToday/index.mjs
+++ b/lambda/getToday/index.mjs
@@ -2,7 +2,8 @@ import { getRowByDate, createRow, parseRow, todayISO } from "../lib/notion.mjs";
 
 export async function handler(event) {
   try {
-    const date = todayISO();
+    const params = new URLSearchParams(event.queryStringParameters || {});
+    const date = params.get("date") || todayISO();
     let row = await getRowByDate(date);
 
     if (!row) {

--- a/lambda/track/index.mjs
+++ b/lambda/track/index.mjs
@@ -43,7 +43,7 @@ function buildPatch(field, value, currentRow) {
 export async function handler(event) {
   try {
     const body = JSON.parse(event.body);
-    const { field, value } = body;
+    const { field, value, date: clientDate } = body;
 
     if (!field || !VALID_FIELDS.includes(field)) {
       return {
@@ -56,7 +56,7 @@ export async function handler(event) {
       };
     }
 
-    const date = todayISO();
+    const date = clientDate || todayISO();
     let row = await getRowByDate(date);
 
     if (!row) {


### PR DESCRIPTION
The todayISO() function on the server used UTC time, causing trackers
to not reset at local midnight for users in non-UTC timezones. The
frontend now computes the local date and sends it to both Lambda
endpoints, which fall back to UTC only if no client date is provided.

Closes #10

https://claude.ai/code/session_01Jd1KHezNJcUx2HVpEJEJLs