### PR TITLE
fix: use UTC date format and URL API in fetchToday

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,11 +13,7 @@ let state = null;
 
 // ---- Date helper ----
 function localTodayISO() {
-  const d = new Date();
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
+  return new Date().toISOString().slice(0, 10);
 }
 
 // ---- DOM helpers ----
@@ -109,7 +105,9 @@ function applyOptimistic(field, value) {
 
 async function fetchToday() {
   const date = localTodayISO();
-  const res = await fetch(`${GET_TODAY_URL}?date=${date}`);
+  const url = new URL(GET_TODAY_URL);
+  url.searchParams.set("date", date);
+  const res = await fetch(url);
   if (!res.ok) throw new Error("Failed to load today's data");
   state = await res.json();
   render();


### PR DESCRIPTION
- Changed localTodayISO() to use toISOString().slice(0, 10) to match
  the backend's todayISO() function, ensuring consistent UTC dates
- Updated fetchToday() to use the URL API for more robust URL
  construction and proper parameter encoding

Fixes #15

https://claude.ai/code/session_01VG3XbneHEVFWLZZWNadxzs